### PR TITLE
Allow discovering Broadlink device at a specific IP

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ In the `docker run` command listed above, the DB files (commands.db and blasters
 Endpoint | HTTP Method | Description
 -------- | ----------- | -----------
 `/discoverblasters` | `GET` | Discovers all new Broadlink RM blasters and adds them to the database (Note: blasters must be in the database before they can be used by the application, and they must be on and connected to the local network to be discoverable. You can add the Broadlink devices to your network using the instructions [here](https://github.com/mjg59/python-broadlink#example-use)). Blasters will be added to the database unnamed, so it's recommended to use `PUT /blasters/<attr>/<value>?new_name=<new_name>` to set a friendly name for each blaster.<br><br>NOTE: Discovery will also update blaster IP addresses when applicable.
+`/discoverblasters?at_ip=<value>` | `GET` | Discovers a Broadlink RM blaster at the specified IP address and adds it to the database. This can be used to discover and add [locked blasters](https://github.com/mjg59/python-broadlink/issues/719), or blasters that otherwise cannot be discovered.
 `/blasters` | `GET` | Gets all blasters (only returns blasters that have already been discovered once). | 
 `/blasters?target_name=<target_name>&command_name=<command_name>` | `POST` | Sends command `<command_name>` for target `<target_name>` to all blasters.
 `/blasters/<attr>/<value>` | `GET` | Gets specified blaster. `<attr>` should be either `ip`, `mac`, or `name`, and `<value>` should be the corresponding value.
@@ -84,6 +85,7 @@ Endpoint | HTTP Method | Description
 2. The database files are in SQLite3 format and can be hand edited if needed. I use [SQLiteStudio](https://sqlitestudio.pl/index.rvt).
 3. To reset all settings/data, simply stop the container/app, delete the two .db files, and restart.
 4. This was tested on an RM3 Mini but should theoretically support any RM device that [python-broadlink](https://github.com/mjg59/python-broadlink) does.
+5. Blasters must be unlocked (accessible via WLAN) to be controlled via this program, otherwise you may get `Authentication failed` errors (see [mjg59/python-broadlink#719](https://github.com/mjg59/python-broadlink/issues/719)). To unlock a blaster in the Broadlink app: select the device, tap "..." in the top tap, click "Property", then find the "Lock device" setting and turn it off.
 
 ## Shout outs
 1. @mjg59 for [python-broadlink](https://github.com/mjg59/python-broadlink)

--- a/app/app.py
+++ b/app/app.py
@@ -86,7 +86,7 @@ class MiddlewareDatabaseHandler(object):
 
 class DiscoverRESTResource(object):
     def on_get(self, req, resp):
-        resp.body = json.dumps(blaster_db.get_new_blasters())
+        resp.body = json.dumps(blaster_db.get_new_blasters(at_ip=req.get_param("at_ip", required=False)))
 
 
 # Resource to interact with all discovered Blasters

--- a/app/db_helpers/blaster_db.py
+++ b/app/db_helpers/blaster_db.py
@@ -142,10 +142,18 @@ def discover_blasters(timeout):
     ]
 
 
-def get_new_blasters(timeout=DISCOVERY_TIMEOUT):
+def get_new_blasters(at_ip=None, timeout=DISCOVERY_TIMEOUT):
     cnt = 0
+    discovered = []
 
-    for blaster in discover_blasters(timeout=timeout):
+    if at_ip:
+        d = broadlink.hello(at_ip)
+        if d:
+            discovered.append(d)
+    else:
+        discovered = discover_blasters(timeout=timeout)
+
+    for blaster in discovered:
         mac_hex = enc_hex(blaster.mac)
         mac = friendly_mac_from_hex(mac_hex)
         check_blaster = Blaster.get_or_none(


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Introduce functionality to discover Broadlink RM blasters at a specific IP address, enhancing the discovery process for locked or otherwise undiscoverable devices. Update the documentation to reflect these changes and provide additional user guidance.

New Features:
- Add the ability to discover a Broadlink RM blaster at a specific IP address using the `/discoverblasters?at_ip=<value>` endpoint.

Enhancements:
- Update the `get_new_blasters` function to accept an optional `at_ip` parameter for targeted blaster discovery.

Documentation:
- Update the README to document the new `/discoverblasters?at_ip=<value>` endpoint and provide additional guidance on unlocking blasters for control.

<!-- Generated by sourcery-ai[bot]: end summary -->