### PR TITLE
Fix incorrect usage of `.available` property

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -207,7 +207,7 @@ class BlasterRESTResource(object):
 
 class BlasterStatusRESTResource(object):
     def on_get(self, req, resp, attr, value):
-        if not get_blaster(attr, value).available():
+        if not get_blaster(attr, value).available:
             raise falcon.HTTPGatewayTimeout(
                 "Blaster with attribute '"
                 + attr


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix the incorrect usage of the `.available` property in the BlasterStatusRESTResource class by removing the method call parentheses.

Bug Fixes:
- Fix incorrect usage of the `.available` property by removing the method call parentheses.

<!-- Generated by sourcery-ai[bot]: end summary -->