### PR TITLE
Fix compatibility with Broadlink RM4C

### DIFF
--- a/app/db_helpers/blaster_db.py
+++ b/app/db_helpers/blaster_db.py
@@ -39,7 +39,7 @@ class Blaster(BaseBlastersModel):
 
     @property
     def device(self):
-        device = broadlink.rm(
+        device = broadlink.rm4(
             host=(self.ip, self.port), mac=dec_hex(self.mac_hex), devtype=self.devtype
         )
         try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-broadlink==0.16.0
 falcon
 gunicorn
 peewee
+broadlink==0.19.0


### PR DESCRIPTION
See: https://github.com/mjg59/python-broadlink/issues/404#issuecomment-703893476

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Fix compatibility with Broadlink RM4C by updating the device instantiation method in the blaster_db module.

Bug Fixes:
- Fix compatibility issue with Broadlink RM4C by updating the device instantiation to use 'broadlink.rm4' instead of 'broadlink.rm'.

<!-- Generated by sourcery-ai[bot]: end summary -->